### PR TITLE
feat: rocks.nvim/luarocks support

### DIFF
--- a/.github/workflows/luarocks.yml
+++ b/.github/workflows/luarocks.yml
@@ -7,7 +7,7 @@ on:
   release:
     types:
       - created
-  pull_request: # Runs test install without uploading
+  pull_request: # Runs test install on PR without uploading
   workflow_dispatch: # Allows to trigger manually
 
 jobs:
@@ -19,11 +19,25 @@ jobs:
           fetch-depth: 0 # Required to count the commits
       - name: Get Version
         run: echo "LUAROCKS_VERSION=$(git describe --abbrev=0 --tags)" >> $GITHUB_ENV
+      - name: Install C/C++ Compiler
+        uses: rlalik/setup-cpp-compiler@master
+        with:
+          compiler: clang-latest
+      - name: Install Lua
+        uses: leso-kn/gh-actions-lua@master
+        with:
+          luaVersion: "5.1"
+      - name: Install Luarocks
+        uses: hishamhm/gh-actions-luarocks@master
+      - name: Install `luarocks-build-treesitter-parser` Package
+        run: |
+          luarocks --verbose --local --lua-version=5.1 install luarocks-build-treesitter-parser
       - name: LuaRocks Upload
         uses: nvim-neorocks/luarocks-tag-release@v5
         env:
           LUAROCKS_API_KEY: ${{ secrets.LUAROCKS_API_KEY }}
         with:
+          name: tree-sitter-orgmode
           version: ${{ env.LUAROCKS_VERSION }}
           labels: |
             neovim

--- a/.github/workflows/luarocks.yml
+++ b/.github/workflows/luarocks.yml
@@ -1,0 +1,32 @@
+name: Push to Luarocks
+
+on:
+  push:
+    tags:
+      - '*'
+  release:
+    types:
+      - created
+  pull_request: # Runs test install without uploading
+  workflow_dispatch: # Allows to trigger manually
+
+jobs:
+  luarocks-upload:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Required to count the commits
+      - name: Get Version
+        run: echo "LUAROCKS_VERSION=$(git describe --abbrev=0 --tags)" >> $GITHUB_ENV
+      - name: LuaRocks Upload
+        uses: nvim-neorocks/luarocks-tag-release@v5
+        env:
+          LUAROCKS_API_KEY: ${{ secrets.LUAROCKS_API_KEY }}
+        with:
+          version: ${{ env.LUAROCKS_VERSION }}
+          labels: |
+            neovim
+            tree-sitter
+          summary: A fork of tree-sitter-org, for use with the orgmode Neovim plugin
+          template: .github/workflows/tree-sitter-orgmode.rockspec.template

--- a/.github/workflows/tree-sitter-orgmode.rockspec.template
+++ b/.github/workflows/tree-sitter-orgmode.rockspec.template
@@ -1,0 +1,32 @@
+local git_ref = '$git_ref'
+local modrev = '$modrev'
+local specrev = '$specrev'
+
+local repo_url = '$repo_url'
+
+rockspec_format = '3.0'
+package = '$package'
+version = modrev ..'-'.. specrev
+
+description = {
+  summary = '$summary',
+  labels = $labels,
+  homepage = '$homepage',
+  $license
+}
+
+build_dependencies = {
+  'luarocks-build-treesitter-parser >= 1.3.0',
+}
+
+source = {
+  url = repo_url .. '/archive/' .. git_ref .. '.zip',
+  dir = '$repo_name-' .. '$archive_dir_suffix',
+}
+
+build = {
+  type = "treesitter-parser",
+  lang = "org",
+  sources = { "src/parser.c", "src/scanner.c" },
+  copy_directories = { "queries" },
+}


### PR DESCRIPTION
Hey :wave: 

### Summary

This PR is part of a push to get neovim plugins on [LuaRocks](https://luarocks.org/labels/neovim).

See also:

- [rocks.nvim](https://github.com/nvim-neorocks/rocks.nvim), a new luarocks-based plugin manager.
- [rocks.nvim's enhanced tree-sitter support](https://github.com/nvim-neorocks/rocks.nvim?tab=readme-ov-file#deciduous_tree-enhanced-tree-sitter-support).
- [this blog post](https://mrcjkb.github.io/posts/2023-01-10-luarocks-tag-release.html).

### Things done:

- Add a workflow that publishes tags to luarocks.org when a tag or release is pushed.
  - To avoid naming conflicts with the existing `tree-sitter-org` package, I have named
    this one `tree-sitter-orgmode`.
    
### Open questions:

- [ ] The `queries` directory here contains queries files that were probably carried over from upstream.
      Neovim would expect something like `queries/org/`.
      I guess you would want to keep the queries in the orgmode plugin, in which case it would make sense to
      remove the `copy_directories` clause in the rockspec template.

### Next steps:

- Add a workflow to the orgmode plugin, which generates a rockspec that has this parser as a dependency.
- Build the parser on [rocks-binaries](https://github.com/nvim-neorocks/rocks-binaries), so that rocks.nvim users
  don't have to compile the parser.

### Notes:

> [!IMPORTANT]
> 
> - **For the luarocks workflow to work, someone with a luarocks.org account will have to add their [API key](https://luarocks.org/settings/api-keys) to this repo's [GitHub actions secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository)**.
> - As this is a fork, you will probably need to enable GitHub Actions in the repository settings.

- Tagged releases are installed locally and then published to luarocks.org.
  - If you push tags from a local checkout, the workflow is triggered automatically.
  - If you use GitHub releases to create tags, you may need to [add a PA token](https://github.com/nvim-neorocks/sample-luarocks-plugin?tab=readme-ov-file#generating-a-pat-personal-access-token) for the workflow to be triggered automatically.
- Due to a shortcoming in LuaRocks (https://github.com/luarocks/luarocks-site/issues/188), the `neovim` and/or `vim` labels have to be added  to the LuaRocks package manually (after the first upload), for this plugin to show up in https://luarocks.org/labels/neovim or https://luarocks.org/labels/vim, respectively.

See also [this guide](https://github.com/vhyrro/sample-luarocks-plugin).